### PR TITLE
Send article to phone

### DIFF
--- a/lambda/custom/.eslintrc
+++ b/lambda/custom/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "jest": true
+  },
   "rules": {
     "quote-props": "off",
     "comma-dangle": "off"

--- a/lambda/custom/__tests__/integration/handlers.test.js
+++ b/lambda/custom/__tests__/integration/handlers.test.js
@@ -25,7 +25,7 @@ class mockNewsApi {
   constructor() {
     this.v2 = {
       'topHeadlines': mockTopHeadLines
-    }
+    };
   }
 }
 jest.mock('newsapi', () => mockNewsApi);
@@ -44,9 +44,7 @@ const handlers = require('../../handlers');
 describe('Handlers testing', () => {
   let mockContext;
   const mockContextResponseListen = jest.fn();
-  const mockContextResponseSpeak = jest.fn(() => {
-    return { 'listen': mockContextResponseListen };
-  });
+  const mockContextResponseSpeak = jest.fn(() => ({ 'listen': mockContextResponseListen }));
   beforeEach(() => {
     jest.resetModules();
     mockContextResponseSpeak.mockClear();
@@ -70,7 +68,6 @@ describe('Handlers testing', () => {
   });
 
   describe('News Inquiry Intent', () => {
-
     it('should return the summary of the top article for a category', () => {
       const newsApiUrl = 'http://api.smmry.com?SM_API_KEY=sak-123&SM_WITH_BREAK&SM_LENGTH=1&SM_URL=http://test.url';
       mockedFetch.withArgs(newsApiUrl)

--- a/lambda/custom/__tests__/integration/handlers.test.js
+++ b/lambda/custom/__tests__/integration/handlers.test.js
@@ -80,6 +80,7 @@ describe('Handlers testing', () => {
       mockTopHeadLines.mockImplementation(() => Promise.resolve(NEWS_API_SUCCESS_1_ARTICLE_RES));
 
       mockContext.event = ALEXA_NEWS_INQUIRY_REQUEST;
+      mockContext.attributes = {};
 
       return handlers.NewsInquiryIntent.call(mockContext)
         .then(() => {
@@ -89,7 +90,7 @@ describe('Handlers testing', () => {
             'country': 'us',
             'pageSize': 1
           });
-          expect(mockContextResponseSpeak).toHaveBeenCalledWith('the top headline is article title<break time="1s"/> Here is the summary:<break time="1s"/>article<break time="1.2s"/>summary');
+          expect(mockContextResponseSpeak).toHaveBeenCalledWith('the top headline is article title<break time="1s"/> Here is the summary:<break time="1s"/>article<break time="1.2s"/>summary<break time="1s"/>would you like me to send the full article to your phone?');
           expect(mockContext.emit).toHaveBeenCalledWith(':responseReady');
         });
     });

--- a/lambda/custom/__tests__/integration/handlers.test.js
+++ b/lambda/custom/__tests__/integration/handlers.test.js
@@ -106,8 +106,11 @@ describe('Handlers testing', () => {
           'country': 'us',
           'pageSize': 1
         });
-        expect(mockContextResponseSpeak).not.toHaveBeenCalled();
-        expect(mockContext.emit).toHaveBeenCalledWith(':tell', 'Sorry something is wrong on my side, please try again in a moment.');
+        expect(mockContextResponseSpeak).toHaveBeenCalledWith('Sorry something is wrong on my side, please try again in a moment.');
+        expect(mockContext.emit).toHaveBeenCalledWith(':responseReady');
+      });
+    });
+  });
 
   describe('AMAZON Yes Intent', () => {
     it('should return a card with the last read article information when the last intent was a news inquiry', () => {

--- a/lambda/custom/__tests__/integration/handlers.test.js
+++ b/lambda/custom/__tests__/integration/handlers.test.js
@@ -131,6 +131,14 @@ describe('Handlers testing', () => {
       });
     });
   });
+
+  describe('AMAZON No Intent', () => {
+    it('should end the conversation with the end sentence', () => {
+      mockContext.attributes = MOCK_ATTRIBUTES;
+
+      return handlers['AMAZON.NoIntent'].call(mockContext).then(() => {
+        expect(mockContextResponseSpeak).toHaveBeenCalledWith('No problem.<break time="0.5s"/>Until I find news again for you. Have a good one.');
+        expect(mockContext.emit).toHaveBeenCalledWith(':responseReady');
       });
     });
   });

--- a/lambda/custom/__tests__/integration/handlers.test.js
+++ b/lambda/custom/__tests__/integration/handlers.test.js
@@ -43,12 +43,13 @@ const handlers = require('../../handlers');
 
 describe('Handlers testing', () => {
   let mockContext;
-  const mockContextResponseListen = jest.fn();
-  const mockContextResponseSpeak = jest.fn(() => ({ 'listen': mockContextResponseListen }));
+  let mockContextResponseListen;
+  let mockContextResponseSpeak;
   beforeEach(() => {
     jest.resetModules();
-    mockContextResponseSpeak.mockClear();
-    mockContextResponseListen.mockClear();
+    jest.resetAllMocks();
+    mockContextResponseListen = jest.fn();
+    mockContextResponseSpeak = jest.fn(() => ({ 'listen': mockContextResponseListen }));
     mockContext = {
       'emit': jest.fn(),
       'response': {
@@ -88,6 +89,7 @@ describe('Handlers testing', () => {
             'pageSize': 1
           });
           expect(mockContextResponseSpeak).toHaveBeenCalledWith('the top headline is article title<break time="1s"/> Here is the summary:<break time="1s"/>article<break time="1.2s"/>summary<break time="1s"/>would you like me to send the full article to your phone?');
+          expect(mockContextResponseSpeak).toHaveBeenCalledTimes(1);
           expect(mockContext.emit).toHaveBeenCalledWith(':responseReady');
         });
     });

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -80,15 +80,15 @@ function newsInquiryIntentHandler() {
   return getTopHeadLine(topic)
     .then((topHeadlineArticle) => {
       topArticle = topHeadlineArticle;
-      return getArticleSummary(topArticle)
-        .then((topArticleSummary) => {
-          functionContext.attributes.lastIntent = INTENT.NEWS_INQUIRY_INTENT;
-          functionContext.attributes.lastReadArticle = topHeadlineArticle;
-          functionContext.response
-            .speak(`the top headline is ${topArticle.title}<break time="1s"/> Here is the summary:<break time="1s"/>${topArticleSummary}<break time="1s"/>would you like me to send the full article to your phone?`)
-            .listen('would you like to get the full article sent to your phone?');
-          return functionContext.emit(':responseReady');
-        });
+      return getArticleSummary(topArticle);
+    })
+    .then((topArticleSummary) => {
+      functionContext.attributes.lastIntent = INTENT.NEWS_INQUIRY_INTENT;
+      functionContext.attributes.lastReadArticle = topArticle;
+      functionContext.response
+        .speak(`the top headline is ${topArticle.title}<break time="1s"/> Here is the summary:<break time="1s"/>${topArticleSummary}<break time="1s"/>would you like me to send the full article to your phone?`)
+        .listen('would you like to get the full article sent to your phone?');
+      return functionContext.emit(':responseReady');
     })
     .catch((err) => {
       logger.log('Error while looking for the summary of the article: ', err);

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -82,7 +82,11 @@ function newsInquiryIntentHandler() {
       topArticle = topHeadlineArticle;
       return getArticleSummary(topArticle)
         .then((topArticleSummary) => {
-          functionContext.response.speak(`the top headline is ${topArticle.title}<break time="1s"/> Here is the summary:<break time="1s"/>${topArticleSummary}`);
+          functionContext.attributes.lastIntent = INTENT.NEWS_INQUIRY_INTENT;
+          functionContext.attributes.lastReadArticle = topHeadlineArticle;
+          functionContext.response
+            .speak(`the top headline is ${topArticle.title}<break time="1s"/> Here is the summary:<break time="1s"/>${topArticleSummary}<break time="1s"/>would you like me to send the full article to your phone?`)
+            .listen('would you like to get the full article sent to your phone?');
           return functionContext.emit(':responseReady');
         });
     })

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -63,7 +63,6 @@ function launchRequestHandler() {
 
 function newsInquiryIntentHandler() {
   const topic = _.get(this.event, 'request.intent.slots.topic.resolutions.resolutionsPerAuthority.0.values.0.value.name');
-  const functionContext = this;
 
   if (_.isNil(topic)) {
     const topicInquiry = 'which topic are you interested in today?';
@@ -83,12 +82,12 @@ function newsInquiryIntentHandler() {
       return getArticleSummary(topArticle);
     })
     .then((topArticleSummary) => {
-      functionContext.attributes.lastIntent = INTENT.NEWS_INQUIRY_INTENT;
-      functionContext.attributes.lastReadArticle = topArticle;
-      functionContext.response
+      this.attributes.lastIntent = INTENT.NEWS_INQUIRY_INTENT;
+      this.attributes.lastReadArticle = topArticle;
+      this.response
         .speak(`the top headline is ${topArticle.title}<break time="1s"/> Here is the summary:<break time="1s"/>${topArticleSummary}<break time="1s"/>would you like me to send the full article to your phone?`)
         .listen('would you like to get the full article sent to your phone?');
-      return functionContext.emit(':responseReady');
+      return this.emit(':responseReady');
     })
     .catch((err) => {
       logger.log('Error while looking for the summary of the article: ', err);

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -92,7 +92,8 @@ function newsInquiryIntentHandler() {
     })
     .catch((err) => {
       logger.log('Error while looking for the summary of the article: ', err);
-      return this.emit(':tell', 'Sorry something is wrong on my side, please try again in a moment.');
+      this.response.speak('Sorry something is wrong on my side, please try again in a moment.');
+      return this.emit(':responseReady');
     });
 }
 

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -130,5 +130,7 @@ function noIntentHandler() {
 
 module.exports = {
   'LaunchRequest': launchRequestHandler,
-  'NewsInquiryIntent': newsInquiryIntentHandler
+  'NewsInquiryIntent': newsInquiryIntentHandler,
+  'AMAZON.YesIntent': yesIntentHandler,
+  'AMAZON.NoIntent': noIntentHandler
 };

--- a/lambda/custom/handlers.js
+++ b/lambda/custom/handlers.js
@@ -13,6 +13,10 @@ const CATEGORIES = [
 
 const SMMRY_API_BASE_URL = `http://api.smmry.com?SM_API_KEY=${config.SMMRY_API_KEY}`;
 
+const INTENT = {
+  'NEWS_INQUIRY_INTENT': 'NEWS_INQUIRY_INTENT'
+};
+
 const replaceAll = (target, search, replacement) => target.replace(new RegExp(search, 'g'), replacement);
 
 const replaceSmmryBreakInText = text => replaceAll(text, '\\[BREAK\\]', '<break time="1.2s"/>');
@@ -86,6 +90,37 @@ function newsInquiryIntentHandler() {
       logger.log('Error while looking for the summary of the article: ', err);
       return this.emit(':tell', 'Sorry something is wrong on my side, please try again in a moment.');
     });
+}
+
+const END_SENTENCE = 'Until I find news again for you. Have a good one.';
+
+function yesIntentHandler() {
+  const lastIntent = _.get(this.attributes, 'lastIntent');
+  if (lastIntent === INTENT.NEWS_INQUIRY_INTENT) {
+    const lastReadArticle = _.get(this.attributes, 'lastReadArticle');
+    const cardTitle = lastReadArticle.title;
+    const cardContent = lastReadArticle.url;
+    const imageObj = {
+      smallImageUrl: lastReadArticle.urlToImage,
+      largeImageUrl: lastReadArticle.urlToImage
+    };
+    this.response
+      .speak(`All right, I have sent the article to your phone.<break time="0.5s"/>${END_SENTENCE}`)
+      .cardRenderer(cardTitle, cardContent, imageObj);
+    this.emit(':responseReady');
+  }
+  return Promise.resolve();
+}
+
+function noIntentHandler() {
+  const lastIntent = _.get(this.attributes, 'lastIntent');
+
+  if (lastIntent === INTENT.NEWS_INQUIRY_INTENT) {
+    this.response
+      .speak(`No problem.<break time="0.5s"/>${END_SENTENCE}`);
+    this.emit(':responseReady');
+  }
+  return Promise.resolve();
 }
 
 module.exports = {

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "lint": "eslint *.js __tests__/**/*.js",
     "test:integration": "jest __tests__/integration/*.test.js",
     "test": "yarn test:integration"
   },

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -28,6 +28,14 @@
             "what is the word around {topic}",
             "give me news about {topic}"
           ]
+        },
+        {
+          "name": "AMAZON.YesIntent",
+          "samples": []
+        },
+        {
+          "name": "AMAZON.NoIntent",
+          "samples": []
         }
       ],
       "types": [


### PR DESCRIPTION
## Description

This pull request adds the feature of sending the article to the phone after reading the summary.
The happy path for the conversation looks like:
```
(U): Alexa, ask taillor news to give me news about tech.
(A): the top headline is Taxes From A To Z (2018): D Is For Direct Deposit Here is the summary: If you want to direct your tax refund to either two or three accounts, Archer MSA, Coverdell education savings account, or a TreasuryDirect® online account, you'll want to file form 8888, Allocation of Refund.would you like me to send the full article to your phone?
(U): Yes.
(A): All right, I have sent the article to your phone.Until I find news again for you. Have a good one.
```

The code also handles the case of the user saying no to the follow up question and just end the conversation politely.

#### Note
- expected output for tests:
```
  Handlers testing
    Launch request
      ✓ should send back a speak, listen response (12ms)
    News Inquiry Intent
      ✓ should return the summary of the top article for a category (9ms)
      ✓ should say that an error occurred if no article was available on news api (3ms)
    AMAZON Yes Intent
      ✓ should return a card with the last read article information when the last intent was a news inquiry (2ms)
    AMAZON No Intent
      ✓ should end the conversation with the end sentence (2ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```
- This PR can be reviewed per commit to ease the review.